### PR TITLE
Refactor CLI to use positional args and support multiple test paths

### DIFF
--- a/cmd/gdunit4-test-runner/main.go
+++ b/cmd/gdunit4-test-runner/main.go
@@ -32,13 +32,13 @@ func run() int {
 		return 2
 	}
 
-	detected, err := detector.Detect(cfg.TestPath)
+	detected, err := detector.Detect(cfg.TestPaths)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "error:", err)
 		return 2
 	}
 
-	result, err := runner.Run(cfg.GodotPath, detected.ProjectDir, detected.ResPath, cfg.Verbose)
+	result, err := runner.Run(cfg.GodotPath, detected.ProjectDir, detected.ResPaths, cfg.Verbose)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "error:", err)
 		return 2

--- a/internal/detector/detector_test.go
+++ b/internal/detector/detector_test.go
@@ -28,15 +28,15 @@ func TestDetect_DirectoryUnderProject(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := Detect(testsDir)
+	result, err := Detect([]string{testsDir})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if result.ProjectDir != root {
 		t.Errorf("ProjectDir = %q, want %q", result.ProjectDir, root)
 	}
-	if result.ResPath != "res://tests/unit" {
-		t.Errorf("ResPath = %q, want %q", result.ResPath, "res://tests/unit")
+	if result.ResPaths[0] != "res://tests/unit" {
+		t.Errorf("ResPaths[0] = %q, want %q", result.ResPaths[0], "res://tests/unit")
 	}
 }
 
@@ -51,37 +51,37 @@ func TestDetect_FileUnderProject(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := Detect(testFile)
+	result, err := Detect([]string{testFile})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if result.ProjectDir != root {
 		t.Errorf("ProjectDir = %q, want %q", result.ProjectDir, root)
 	}
-	if result.ResPath != "res://tests/MyTest.gd" {
-		t.Errorf("ResPath = %q, want %q", result.ResPath, "res://tests/MyTest.gd")
+	if result.ResPaths[0] != "res://tests/MyTest.gd" {
+		t.Errorf("ResPaths[0] = %q, want %q", result.ResPaths[0], "res://tests/MyTest.gd")
 	}
 }
 
 func TestDetect_ProjectRootItself(t *testing.T) {
 	root := makeProject(t)
 
-	result, err := Detect(root)
+	result, err := Detect([]string{root})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if result.ProjectDir != root {
 		t.Errorf("ProjectDir = %q, want %q", result.ProjectDir, root)
 	}
-	if result.ResPath != "res://." {
-		t.Errorf("ResPath = %q, want res://.", result.ResPath)
+	if result.ResPaths[0] != "res://." {
+		t.Errorf("ResPaths[0] = %q, want res://.", result.ResPaths[0])
 	}
 }
 
 func TestDetect_NoProjectGodot(t *testing.T) {
 	dir := t.TempDir()
 
-	_, err := Detect(dir)
+	_, err := Detect([]string{dir})
 	if err == nil {
 		t.Fatal("expected error when project.godot is missing, got nil")
 	}
@@ -97,7 +97,7 @@ func TestDetect_MissingGdUnit4Addon(t *testing.T) {
 	}
 	// Do NOT create addons/gdUnit4
 
-	_, err := Detect(root)
+	_, err := Detect([]string{root})
 	if err == nil {
 		t.Fatal("expected error when addons/gdUnit4 is missing, got nil")
 	}
@@ -113,14 +113,66 @@ func TestDetect_DeepNestedPath(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := Detect(deep)
+	result, err := Detect([]string{deep})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if result.ProjectDir != root {
 		t.Errorf("ProjectDir = %q, want %q", result.ProjectDir, root)
 	}
-	if result.ResPath != "res://a/b/c/d" {
-		t.Errorf("ResPath = %q, want res://a/b/c/d", result.ResPath)
+	if result.ResPaths[0] != "res://a/b/c/d" {
+		t.Errorf("ResPaths[0] = %q, want res://a/b/c/d", result.ResPaths[0])
+	}
+}
+
+func TestDetect_MultiplePaths(t *testing.T) {
+	root := makeProject(t)
+	dir1 := filepath.Join(root, "tests", "unit")
+	dir2 := filepath.Join(root, "tests", "integration")
+	if err := os.MkdirAll(dir1, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(dir2, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := Detect([]string{dir1, dir2})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ProjectDir != root {
+		t.Errorf("ProjectDir = %q, want %q", result.ProjectDir, root)
+	}
+	if len(result.ResPaths) != 2 {
+		t.Fatalf("len(ResPaths) = %d, want 2", len(result.ResPaths))
+	}
+	if result.ResPaths[0] != "res://tests/unit" {
+		t.Errorf("ResPaths[0] = %q, want res://tests/unit", result.ResPaths[0])
+	}
+	if result.ResPaths[1] != "res://tests/integration" {
+		t.Errorf("ResPaths[1] = %q, want res://tests/integration", result.ResPaths[1])
+	}
+}
+
+func TestDetect_CrossProjectError(t *testing.T) {
+	// Create two separate Godot projects.
+	root1 := makeProject(t)
+	root2 := makeProject(t)
+
+	dir1 := filepath.Join(root1, "tests")
+	if err := os.MkdirAll(dir1, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dir2 := filepath.Join(root2, "tests")
+	if err := os.MkdirAll(dir2, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Detect([]string{dir1, dir2})
+	if err == nil {
+		t.Fatal("expected error when paths belong to different projects, got nil")
+	}
+	if !strings.Contains(err.Error(), "different Godot project") {
+		t.Errorf("error message should mention different project, got: %v", err)
 	}
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -14,21 +14,24 @@ type RunResult struct {
 }
 
 // BuildArgs constructs the Godot command arguments for gdUnit4.
-func BuildArgs(resPath string) []string {
-	return []string{
+// Each path in resPaths is passed as a separate -a flag.
+func BuildArgs(resPaths []string) []string {
+	args := []string{
 		"--headless",
 		"-s", "-d",
 		"res://addons/gdUnit4/bin/GdUnitCmdTool.gd",
-		"-a", resPath,
-		"--ignoreHeadlessMode",
-		"-c",
 	}
+	for _, p := range resPaths {
+		args = append(args, "-a", p)
+	}
+	args = append(args, "--ignoreHeadlessMode", "-c")
+	return args
 }
 
 // Run executes Godot with gdUnit4 arguments from projectDir.
 // Output is captured to a temporary log file; if verbose is true it is also written to stderr.
-func Run(godotPath, projectDir, resPath string, verbose bool) (*RunResult, error) {
-	args := BuildArgs(resPath)
+func Run(godotPath, projectDir string, resPaths []string, verbose bool) (*RunResult, error) {
+	args := BuildArgs(resPaths)
 	cmd := exec.Command(godotPath, args...)
 	cmd.Dir = projectDir
 


### PR DESCRIPTION
## Summary

- `--path` フラグを廃止し、positional arguments に変更 (省略時はデフォルト `"."`)
- `-v` / `-V` 短縮フラグを削除 (`--verbose` / `--version` のみ残す)
- 複数パスをサポート: `gdunit4-test-runner tests/unit tests/integration foo.gd`
- `Config.TestPath string` → `TestPaths []string`
- `detector.Result.ResPath string` → `ResPaths []string`; 異なるプロジェクト間のパス混在を検証
- `runner.BuildArgs` / `Run` が `[]string` を受け取り、パスごとに `-a` フラグを生成
- README.md・CLAUDE.md を新インターフェースに合わせて更新

**Before:**
```
gdunit4-test-runner --path tests/unit --godot-path /usr/bin/godot -v
```

**After:**
```
gdunit4-test-runner tests/unit
gdunit4-test-runner --godot-path /usr/bin/godot --verbose tests/unit tests/integration
gdunit4-test-runner   # パス省略時は "." (カレントディレクトリ)
```

## Test plan

- [ ] `go test ./...` がすべてパスする
- [ ] `go build ./cmd/gdunit4-test-runner` が成功する
- [ ] `./gdunit4-test-runner --help` が新しい Usage を表示する
- [ ] `./gdunit4-test-runner --version` が正常に動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)