### PR TITLE
Fix false positive crash detection for Godot ENGINE: logs

### DIFF
--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -70,7 +70,6 @@ type Summary struct {
 type CrashDetails struct {
 	CrashInfo    string `json:"crash_info,omitempty"`
 	ScriptErrors string `json:"script_errors,omitempty"`
-	EngineErrors string `json:"engine_errors,omitempty"`
 }
 
 // Failure represents a single test failure.
@@ -186,7 +185,6 @@ func DetectCrash(logPath string) (*CrashDetails, error) {
 
 	var crashLines []string
 	var scriptErrorLines []string
-	var engineErrorLines []string
 
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
@@ -196,22 +194,19 @@ func DetectCrash(logPath string) (*CrashDetails, error) {
 			crashLines = append(crashLines, line)
 		case strings.HasPrefix(line, "SCRIPT ERROR:"):
 			scriptErrorLines = append(scriptErrorLines, line)
-		case strings.HasPrefix(line, "ERROR:"):
-			engineErrorLines = append(engineErrorLines, line)
 		}
 	}
 	if err := scanner.Err(); err != nil {
 		return nil, fmt.Errorf("failed to read log file: %w", err)
 	}
 
-	if len(crashLines) == 0 && len(scriptErrorLines) == 0 && len(engineErrorLines) == 0 {
+	if len(crashLines) == 0 && len(scriptErrorLines) == 0 {
 		return nil, nil
 	}
 
 	return &CrashDetails{
 		CrashInfo:    strings.Join(crashLines, "\n"),
 		ScriptErrors: strings.Join(scriptErrorLines, "\n"),
-		EngineErrors: strings.Join(engineErrorLines, "\n"),
 	}, nil
 }
 


### PR DESCRIPTION
## Summary

- `DetectCrash` が `ERROR:` プレフィックスを持つ全行をクラッシュと判定していた誤検知を修正
- Godot 終了時の定型警告（`ERROR: 150 resources still in use at exit` 等）やアプリケーションログの `ERROR:` 行はクラッシュではないため、検出対象から除外
- 真のクラッシュは `handle_crash:` と `SCRIPT ERROR:` の2パターンで十分に検出可能

## Changes

- `CrashDetails.EngineErrors` フィールドを削除
- `DetectCrash` の `ERROR:` プレフィックス検出を削除
- `TestDetectCrash_EngineErrorOnly_NoCrash` テストを追加（回帰防止）
- `TestDetectCrash_WithCrash` から `EngineErrors` アサーションを削除

## Test plan

- [x] `go test ./...` 全パッケージ通過
- [x] `go vet ./...` エラーなし
- [x] `godot-ddd-starter-kits` (Godot 4.6.1) で手動実行 → 136/136 通過、`crashed: false`、exit code 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)