### PR TITLE
Fix release workflow to trigger on semver tags without v prefix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - "v*"
+      - "[0-9]*"
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

- Change the release workflow trigger pattern from `v*` to `[0-9]*` so that tags like `0.1.0` trigger the release pipeline instead of requiring a `v` prefix (e.g., `v0.1.0`)

## Test plan

- [ ] Merge this PR into main
- [ ] Create and push tag `0.1.0`
- [ ] Confirm the release workflow fires and creates a GitHub Release with Linux and Windows binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)