### PR TITLE
Fix isExecutable() always returning false on Windows

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 )
 
 // ErrVersion is returned by Parse when the user requests --version.
@@ -102,6 +103,9 @@ func isExecutable(path string) bool {
 	}
 	if info.IsDir() {
 		return false
+	}
+	if runtime.GOOS == "windows" {
+		return true
 	}
 	return info.Mode()&0o111 != 0
 }


### PR DESCRIPTION
## Summary

- `isExecutable()` in `internal/config/config.go` used Unix permission bits (`0o111`) to check executability, but `os.Stat` on Windows never sets these bits
- This caused `--godot-path` and `GODOT_PATH` to always be rejected with _"Godot binary not found or not executable"_ on Windows
- Added a `runtime.GOOS == "windows"` branch that skips the permission check — on Windows, a file that exists and is not a directory is considered executable (executability is determined by file extension at the OS level)

## Test plan

- [ ] `go test ./internal/config/...` passes
- [ ] `go vet ./...` passes
- [ ] On Windows: `--godot-path D:\Godot\Godot_v4.x-stable_win64.exe` resolves correctly without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)