### PR TITLE
Fix --verbose hanging on Windows by avoiding pipe creation

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"sync"
+	"time"
 )
 
 // RunResult holds the outcome of running Godot.
@@ -41,20 +43,32 @@ func Run(godotPath, projectDir string, resPaths []string, verbose bool) (*RunRes
 	}
 	tmpPath := tmpFile.Name()
 
-	var writer io.Writer
+	// Always pass *os.File directly — avoids pipe creation that hangs on Windows
+	// when child processes inherit the pipe handle and keep it open after Godot exits.
+	cmd.Stdout = tmpFile
+	cmd.Stderr = tmpFile
+
+	var wg sync.WaitGroup
+	var stopTail chan struct{}
 	if verbose {
-		writer = io.MultiWriter(tmpFile, os.Stderr)
-	} else {
-		writer = tmpFile
+		stopTail = make(chan struct{})
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			tailToStderr(tmpPath, stopTail)
+		}()
 	}
 
-	cmd.Stdout = writer
-	cmd.Stderr = writer
-
 	runErr := cmd.Run()
+
 	// Close the temp file before returning so callers can read it.
 	if closeErr := tmpFile.Close(); closeErr != nil && runErr == nil {
 		runErr = closeErr
+	}
+
+	if verbose {
+		close(stopTail)
+		wg.Wait()
 	}
 
 	exitCode := 0
@@ -72,4 +86,32 @@ func Run(godotPath, projectDir string, resPaths []string, verbose bool) (*RunRes
 		ExitCode: exitCode,
 		LogFile:  tmpPath,
 	}, nil
+}
+
+// tailToStderr reads path and writes new data to stderr until stop is closed,
+// then drains any remaining data and returns.
+func tailToStderr(path string, stop <-chan struct{}) {
+	f, err := os.Open(path)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+
+	buf := make([]byte, 4096)
+	for {
+		n, err := f.Read(buf)
+		if n > 0 {
+			os.Stderr.Write(buf[:n])
+		}
+		if err != nil {
+			select {
+			case <-stop:
+				// Process exited — drain remaining data and return.
+				io.Copy(os.Stderr, f)
+				return
+			default:
+				time.Sleep(50 * time.Millisecond)
+			}
+		}
+	}
 }


### PR DESCRIPTION
## Summary

- `--verbose` 使用時に `io.MultiWriter(tmpFile, os.Stderr)` を使っていたため、Go の `os/exec` が内部的にパイプを生成していた
- Windows では Godot の子プロセス（GPU ワーカー等）がパイプハンドルを継承し、Godot 終了後もハンドルが解放されず `cmd.Wait()` が無限ブロックする問題があった
- `cmd.Stdout`/`cmd.Stderr` を常に `*os.File` 直渡しに変更してパイプ生成を回避
- verbose 時は別 goroutine の `tailToStderr` がログファイルを tail して stderr へ中継する方式に切り替えた

## Test plan

- [ ] `go test ./internal/runner/...` がパスすること
- [ ] `go vet ./...` がエラーなしで通ること
- [ ] Windows 環境で `--verbose` 付き実行がハングしないこと（手動確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)