### PR TITLE
Fix Windows hang by removing -d flag and simplifying stdin to DevNull

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ internal/report/
 
 **`internal/runner`**
 - Accepts godotPath, projectDir, resPaths, verbose
-- Constructs the Godot command: `godot --headless -s -d res://addons/gdUnit4/bin/GdUnitCmdTool.gd -a <path1> -a <path2> --ignoreHeadlessMode -c`
+- Constructs the Godot command: `godot --headless -s res://addons/gdUnit4/bin/GdUnitCmdTool.gd -a <path1> -a <path2> --ignoreHeadlessMode -c`
 - Sets `cmd.Dir = projectDir` (runs from project root)
 - Captures stdout+stderr to a temp log file
 - If verbose, tees output to stderr via `io.MultiWriter`
@@ -99,7 +99,7 @@ Use `flag.NewFlagSet` + `ContinueOnError` for testability. Positional arguments 
 
 ```go
 // Multiple -a flags for multiple paths
-args := []string{"--headless", "-s", "-d", "res://addons/gdUnit4/bin/GdUnitCmdTool.gd"}
+args := []string{"--headless", "-s", "res://addons/gdUnit4/bin/GdUnitCmdTool.gd"}
 for _, p := range resPaths {
     args = append(args, "-a", p)
 }

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ gdunit4-test-runner tests/ | jq .summary
 2. **Path conversion**: Converts each filesystem path to a `res://`-relative path.
 3. **Execution**: Runs Godot from the project directory:
    ```
-   godot --headless -s -d res://addons/gdUnit4/bin/GdUnitCmdTool.gd -a <res://path1> -a <res://path2> --ignoreHeadlessMode -c
+   godot --headless -s res://addons/gdUnit4/bin/GdUnitCmdTool.gd -a <res://path1> -a <res://path2> --ignoreHeadlessMode -c
    ```
 4. **Output capture**: Captures Godot stdout+stderr to a temp log file; if `--verbose` is set, also tees to stderr.
 5. **Crash detection**: Scans the log for `handle_crash:`, `SCRIPT ERROR:`, and `ERROR:` patterns.

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -16,12 +16,13 @@ func TestBuildArgs_SinglePath(t *testing.T) {
 	if !contains(args, "--headless") {
 		t.Error("args should contain --headless")
 	}
-	// Must include -s and -d
+	// Must include -s
 	if !contains(args, "-s") {
 		t.Error("args should contain -s")
 	}
-	if !contains(args, "-d") {
-		t.Error("args should contain -d")
+	// Must NOT include -d (causes interactive debugger hang on Windows)
+	if contains(args, "-d") {
+		t.Error("args should not contain -d")
 	}
 	// Must include the GdUnitCmdTool.gd script
 	if !contains(args, "res://addons/gdUnit4/bin/GdUnitCmdTool.gd") {


### PR DESCRIPTION
## Summary

- `-d` フラグを除去: Godot の LocalDebugger を起動するフラグで、ヘッドレス CI 実行では不要。gdUnit4 は JUnit XML でテスト結果を報告するためデバッガは使われない
- stdin を `os.Pipe()` から `os.DevNull` に変更: Windows では閉じたパイプが `feof(stdin)=true` を確実にセットしないため、よりシンプルなクロスプラットフォーム対応の `/dev/null` (`NUL`) にリダイレクト

Closes #15

## Test plan

- [x] `go build ./cmd/gdunit4-test-runner` — ビルド成功
- [x] `go test ./...` — 全テスト通過
- [x] `go vet ./...` — エラーなし
- [x] 実プロジェクト (`edanoue/godot-ddd-starter-kits`) で手動テスト: 142 テスト全 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)